### PR TITLE
Don't create server defaults from callable string defaults.

### DIFF
--- a/sqlalchemy_defaults/__init__.py
+++ b/sqlalchemy_defaults/__init__.py
@@ -115,7 +115,8 @@ class ModelConfigurator(object):
         """
         Assigns string column server_default based on column default value
         """
-        if column.default is not None:
+        if column.default is not None and (
+                isinstance(column.default.arg, basestring)):
             column.server_default = sa.schema.DefaultClause(column.default.arg)
 
     def assign_boolean_defaults(self, column):

--- a/tests/test_lazy_configurable.py
+++ b/tests/test_lazy_configurable.py
@@ -38,6 +38,11 @@ class TestCase(object):
             is_active = Column(Boolean)
             is_admin = Column(Boolean, default=True)
             hobbies = Column(Unicode(255), default=u'football')
+            favorite_hobbies = Column(Unicode(255), default=lambda ctx: (
+                ctx.current_parameters['hobbies']
+                if ctx.current_parameters['hobbies'] is not None
+                else u'football'
+            ))
             created_at = Column(sa.DateTime, info={'auto_now': True})
             description = Column(sa.UnicodeText)
 
@@ -87,6 +92,9 @@ class TestLazyConfigurableDefaults(TestCase):
 
     def test_assigns_string_server_defaults(self):
         assert self.columns.hobbies.server_default.arg == u'football'
+
+    def test_doesnt_assign_string_server_defaults_for_callables(self):
+        assert self.columns.favorite_hobbies.server_default is None
 
     def test_assigns_int_server_defaults(self):
         assert self.columns.age.server_default.arg == '16'


### PR DESCRIPTION
These changes make it possible to use a callable default value for strings. For example:

```
class User(Model):
    default_color = Column(Unicode(7), default=u'#EE9966')

class Post(Model):
    color = Column(Unicode(7), default=lambda: (
        current_user.default_color if current_user else '#EE9966'
    ))
```

This doesn't work prior to the change because callables can't be used as values for server_default - in order to use a callable default one has to turn off string defaults for the entire model. After the change server_default isn't set for the columns with callable defaults, but is still set normally for other columns. The same approach is already used for integer columns.
