### PR TITLE
AttributeError: 'Sequence' object has no attribute 'arg'

### DIFF
--- a/sqlalchemy_defaults/__init__.py
+++ b/sqlalchemy_defaults/__init__.py
@@ -4,7 +4,7 @@ import six
 import sqlalchemy as sa
 
 
-__version__ = '0.4.1'
+__version__ = '0.4.2'
 
 
 class Column(sa.Column):
@@ -106,7 +106,8 @@ class ModelConfigurator(object):
         """
         Assigns int column server_default based on column default value
         """
-        if column.default is not None:
+        if (column.default is not None and
+                isinstance(column.default, sa.schema.ColumnDefault)):
             if (isinstance(column.default.arg, six.text_type) or
                     isinstance(column.default.arg, six.integer_types)):
                 column.server_default = sa.schema.DefaultClause(


### PR DESCRIPTION
Hi, thanks for the library!
I just started integrating it and had the above error with the Oracle dialect after passing in a `Sequence` object for `default`.

However, I need to pass in a sequence to simulate an auto-incrementing ID:

``` python
id = Column(Integer, default=Sequence('id_seq'), primary_key=True)
```

This fix solves the problem by explicity checking if `column.default` is a`ColumnDefault` instance.

What do you think?
