### PR TITLE
Default to empty string for String based fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ var
 sdist
 develop-eggs
 .installed.cfg
+.cache
 lib
 lib64
 
@@ -28,6 +29,9 @@ nosetests.xml
 
 # Translations
 *.mo
+
+# SublimeText
+*.sublime-*
 
 # Mr Developer
 .mr.developer.cfg

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+known_first_party=sqlalchemy_defaults,tests
+line_length=79
+multi_line_output=3
+not_skip=__init__.py
+order_by_type=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 addons:
   postgresql: 9.3
 
@@ -16,6 +17,7 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
 install:
   - pip install -e ".[test]"
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,40 @@
 sudo: false
+language: python
 addons:
   postgresql: 9.3
 
 env:
-  - DB=mysql
-  - DB=postgres
-  - DB=sqlite
+  global:
+    - POSTGRESQL_DSN=postgresql://postgres@localhost/sqlalchemy_defaults_test
+    - MYSQL_DSN=mysql+pymysql://travis@localhost/sqlalchemy_defaults_test
 
 before_script:
-  - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'create database sqlalchemy_defaults_test;' -U postgres; fi"
-  - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database sqlalchemy_defaults_test;'; fi"
+  - psql -c 'create database sqlalchemy_defaults_test;' -U postgres
+  - mysql -e 'create database sqlalchemy_defaults_test;'
 
-language: python
-python:
-  - 2.6
-  - 2.7
-  - 3.3
-  - 3.4
-  - 3.5
+matrix:
+  include:
+  - python: 2.6
+    env:
+      - 'TOXENV="py26-{sqlite,postgresql,mysql}"'
+  - python: 2.7
+    env:
+      - 'TOXENV="py27-{sqlite,postgresql,mysql}"'
+  - python: 3.3
+    env:
+      - 'TOXENV="py33-{sqlite,postgresql,mysql}"'
+  - python: 3.4
+    env:
+      - 'TOXENV="py34-{sqlite,postgresql,mysql}"'
+  - python: 3.5
+    env:
+      - 'TOXENV="py35-{sqlite,postgresql,mysql}"'
+  - python: 2.7
+    env:
+      - "TOXENV=lint"
+
 install:
-  - pip install -e ".[test]"
+  - pip install tox
+
 script:
-  - py.test
+  - tox

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,25 @@ SQLAlchemy-Defaults
 
 Smart SQLAlchemy defaults for lazy guys, like me.
 
+Running the tests
+-----------------
+
+You need PostgreSQL and MySQL installed to run the full test suite.
+
+To run:
+::
+    $ pip install tox
+    $ POSTGRESQL_DSN='postgresql://user@host:port/db' \
+    MYSQL_DSN='mysql+pymysql://user@host:port/db' \
+    tox
+
+
+To type a bit less to run the tests you can save the command in a script:
+::
+    $ echo "POSTGRESQL_DSN='postgresql://user@host:port/db' \\ \\nMYSQL_DSN='mysql+pymysql://user@host:port/db' \\ \\ntox" > tox.sh
+    $ chmod +x tox.sh
+    $ ./tox.sh
+
 
 Resources
 ---------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,3 +111,31 @@ After you've defined all your models you need to make desired mapper lazy config
 
 
     make_lazy_configured(sa.orm.mapper)
+
+
+make_lazy_configured can also be passed in a global set of default options to use like this:
+::
+
+    make_lazy_configured(
+        sa.orm.mapper,
+        numeric_defaults=False,
+        enum_names=False
+    )
+
+
+Caveats
+-------
+
+Please note that at the time of writing `MySQL does not support setting server defaults for columns of TEXT type <http://dev.mysql.com/doc/refman/5.7/en/blob.html>`_, which means that you will have to set the option ``text_server_defaults`` to ``False`` to avoid errors if you're using TEXT columns:
+::
+
+    make_lazy_configured(sa.orm.mapper, text_server_defaults=False)
+
+When using ``DATETIME`` fields in MySQL versions before 5.6.5 you should also pass in ``auto_now=False`` `as NOW is not a supported argument to DEFAULT below that version <http://dev.mysql.com/doc/refman/5.6/en/timestamp-initialization.html>`_:
+::
+
+    make_lazy_configured(
+        sa.orm.mapper,
+        text_server_defaults=False,
+        auto_now=False
+    )

--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,13 @@ def get_version():
 
 extras_require = {
     'test': [
-        'pytest==2.2.3',
+        'pytest>=2.9.1',
         'Pygments>=1.2',
         'Jinja2>=2.3',
         'docutils>=0.10',
         'flexmock>=0.9.7',
         'psycopg2>=2.4.6',
-        'PyMySQL==0.6.1',
+        'PyMySQL>=0.7.2',
     ]
 }
 
@@ -68,6 +68,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ]

--- a/sqlalchemy_defaults/__init__.py
+++ b/sqlalchemy_defaults/__init__.py
@@ -4,7 +4,7 @@ from inspect import isclass
 import six
 import sqlalchemy as sa
 
-__version__ = '0.4.4'
+__version__ = '0.4.4.dev1'
 
 
 class Column(sa.Column):

--- a/sqlalchemy_defaults/__init__.py
+++ b/sqlalchemy_defaults/__init__.py
@@ -1,8 +1,8 @@
 from datetime import date, datetime
 from inspect import isclass
+
 import six
 import sqlalchemy as sa
-
 
 __version__ = '0.4.4'
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,16 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
-import sqlalchemy as sa
-from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
 
-from sqlalchemy_defaults import make_lazy_configured
-
-IS_MYSQL = (
-    os.environ.get('DB') == 'mysql' or
-    os.environ.get('DSN', '').startswith('mysql')
-)
+IS_MYSQL = os.environ.get('DSN', '').startswith('mysql')
 MYSQLD_VERSION = tuple(
     int(i) for i in
     os.popen('mysqld -V').read()
@@ -19,57 +10,3 @@ MYSQLD_VERSION = tuple(
     .split('.')
     if i.isdigit()
 )
-
-
-def _get_default_settings_overrides():
-    kw = {}
-    if IS_MYSQL:
-        # MySQL (at least up till version 5.7) does not support a default
-        # value for TEXT type columns.
-        kw['text_server_defaults'] = False
-
-        if MYSQLD_VERSION:
-            if MYSQLD_VERSION < (5, 7):
-                # NOW() is not supported as a DEFAULT value below version 5.7
-                kw['auto_now'] = False
-    return kw
-
-
-make_lazy_configured(
-    sa.orm.mapper,
-    **_get_default_settings_overrides()
-)
-
-
-class TestCase(object):
-    def get_dsn_from_driver(self, driver):
-        if driver == 'postgres':
-            return 'postgres://postgres@localhost/sqlalchemy_defaults_test'
-        elif driver == 'mysql':
-            return 'mysql+pymysql://travis@localhost/sqlalchemy_defaults_test'
-        elif driver == 'sqlite':
-            return 'sqlite:///:memory:'
-        else:
-            raise Exception('Unknown driver given: %r' % driver)
-
-    def setup_method(self, method):
-        driver = os.environ.get('DB', 'sqlite')
-        dsn = os.environ.get('DSN', None)
-        if dsn is None:
-            dsn = self.get_dsn_from_driver(driver)
-        self.engine = create_engine(dsn)
-        self.Model = declarative_base()
-
-        self.create_models(**self.column_options)
-        sa.orm.configure_mappers()
-        if hasattr(self, 'User'):
-            self.columns = self.User.__table__.c
-        self.Model.metadata.create_all(self.engine)
-
-        Session = sessionmaker(bind=self.engine)
-        self.session = Session()
-
-    def teardown_method(self, method):
-        self.session.close_all()
-        self.Model.metadata.drop_all(self.engine)
-        self.engine.dispose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import os
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+from sqlalchemy_defaults import make_lazy_configured
+
+from . import IS_MYSQL, MYSQLD_VERSION
+
+
+@pytest.fixture(scope='session')
+def dsn():
+    return os.environ.get('DSN') or 'sqlite:///:memory:'
+
+
+@pytest.fixture
+def Base():
+    return declarative_base()
+
+
+@pytest.yield_fixture
+def engine(dsn):
+    engine = create_engine(dsn)
+    yield engine
+    engine.dispose()
+
+
+@pytest.fixture
+def models():
+    return []
+
+
+@pytest.fixture
+def lazy_options():
+    return {}
+
+
+@pytest.yield_fixture
+def Session(Base, engine, models):
+    sa.orm.configure_mappers()
+    Base.metadata.create_all(engine)
+    yield sessionmaker(bind=engine)
+    Base.metadata.drop_all(engine)
+
+
+@pytest.yield_fixture
+def session(Session):
+    session = Session()
+    yield session
+    session.close_all()
+
+
+@pytest.fixture
+def default_options():
+    opts = {}
+    if IS_MYSQL:
+        # MySQL (at least up till version 5.7) does not support a default
+        # value for TEXT type columns.
+        opts['text_server_defaults'] = False
+
+        if MYSQLD_VERSION:
+            if MYSQLD_VERSION < (5, 7):
+                # NOW() is not supported as a DEFAULT value below version 5.7
+                opts['auto_now'] = False
+    return opts
+
+
+@pytest.fixture
+def lazy_configured(default_options, models, session):
+    for model in models:
+        make_lazy_configured(
+            sa.orm.mapper,
+            **default_options
+        )

--- a/tests/test_boolean_defaults.py
+++ b/tests/test_boolean_defaults.py
@@ -1,38 +1,44 @@
 # -*- coding: utf-8 -*-
+import pytest
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import false, true
 
 from sqlalchemy_defaults import Column
-from tests import TestCase
 
 
-class TestBooleanDefaults(TestCase):
-    column_options = {}
+@pytest.fixture
+def User(Base, lazy_options):
+    class User(Base):
+        __tablename__ = 'user'
+        __lazy_options__ = lazy_options
 
-    def create_models(self, **options):
-        class User(self.Model):
-            __tablename__ = 'user'
-            __lazy_options__ = options
+        id = Column(sa.Integer, primary_key=True)
+        is_active = Column(sa.Boolean)
+        nullable_boolean = Column(sa.Boolean, nullable=True)
+        is_admin = Column(sa.Boolean, default=True)
+    return User
 
-            id = Column(sa.Integer, primary_key=True)
-            is_active = Column(sa.Boolean)
-            nullable_boolean = Column(sa.Boolean, nullable=True)
-            is_admin = Column(sa.Boolean, default=True)
 
-        self.User = User
+@pytest.fixture
+def models(User):
+    return [User]
 
-    def test_booleans_not_nullable_by_default(self):
-        assert self.columns.is_active.nullable is False
 
-    def test_supports_nullable_booleans(self):
-        assert self.columns.nullable_boolean.nullable
+@pytest.mark.usefixtures('lazy_configured')
+class TestBooleanDefaults(object):
 
-    def test_booleans_false(self):
-        assert self.columns.is_active.default.arg is False
+    def test_booleans_not_nullable_by_default(self, User):
+        assert User.__table__.c.is_active.nullable is False
 
-    def test_assigns_boolean_server_defaults(self):
-        is_admin = self.columns.is_admin
-        is_active = self.columns.is_active
+    def test_supports_nullable_booleans(self, User):
+        assert User.__table__.c.nullable_boolean.nullable
+
+    def test_booleans_false(self, User):
+        assert User.__table__.c.is_active.default.arg is False
+
+    def test_assigns_boolean_server_defaults(self, User):
+        is_admin = User.__table__.c.is_admin
+        is_active = User.__table__.c.is_active
         assert is_admin.default.arg is True
 
         assert is_admin.server_default.arg.__class__ == true().__class__

--- a/tests/test_datetime_defaults.py
+++ b/tests/test_datetime_defaults.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 from datetime import date, datetime
 import sqlalchemy as sa
 
 from sqlalchemy_defaults import Column
-from tests import TestCase
+from tests import MYSQLD_VERSION, TestCase
 
 
 class TestDateTimeDefaults(TestCase):
@@ -22,6 +24,10 @@ class TestDateTimeDefaults(TestCase):
 
         self.User = User
 
+    @pytest.mark.skipif(
+        MYSQLD_VERSION and MYSQLD_VERSION < (5, 6, 5),
+        reason='Not testing when MySQL is below version 5.6.5'
+    )
     def test_autonow(self):
         column = self.User.created_at
         assert isinstance(column.default.arg(column), datetime)

--- a/tests/test_datetime_defaults.py
+++ b/tests/test_datetime_defaults.py
@@ -1,35 +1,44 @@
 # -*- coding: utf-8 -*-
-import pytest
-
 from datetime import date, datetime
+
+import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_defaults import Column
-from tests import MYSQLD_VERSION, TestCase
+
+from . import MYSQLD_VERSION
 
 
-class TestDateTimeDefaults(TestCase):
-    column_options = {}
+@pytest.fixture
+def User(Base, lazy_options):
 
-    def create_models(self, **options):
-        class User(self.Model):
-            __tablename__ = 'user'
-            __lazy_options__ = options
+    class User(Base):
+        __tablename__ = 'user'
+        __lazy_options__ = lazy_options
 
-            id = Column(sa.Integer, primary_key=True)
-            created_at = Column(sa.DateTime, auto_now=True)
-            fav_day = Column(
-                sa.Date, min=date(2000, 1, 1), max=date(2099, 1, 1)
-            )
+        id = Column(sa.Integer, primary_key=True)
+        created_at = Column(sa.DateTime, auto_now=True)
+        fav_day = Column(
+            sa.Date, min=date(2000, 1, 1), max=date(2099, 1, 1)
+        )
 
-        self.User = User
+    return User
+
+
+@pytest.fixture
+def models(User):
+    return [User]
+
+
+@pytest.mark.usefixtures('lazy_configured')
+class TestDateTimeDefaults(object):
 
     @pytest.mark.skipif(
         MYSQLD_VERSION and MYSQLD_VERSION < (5, 6, 5),
         reason='Not testing when MySQL is below version 5.6.5'
     )
-    def test_autonow(self):
-        column = self.User.created_at
+    def test_autonow(self, User):
+        column = User.created_at
         assert isinstance(column.default.arg(column), datetime)
         assert (
             column.server_default.arg.__class__ == sa.func.now().__class__

--- a/tests/test_float_defaults.py
+++ b/tests/test_float_defaults.py
@@ -1,28 +1,33 @@
 # -*- coding: utf-8 -*-
+import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_defaults import Column
-from tests import TestCase
 
 
-class TestFloatDefaults(TestCase):
-    column_options = {}
+@pytest.fixture
+def Account(Base, lazy_options):
+    class Account(Base):
+        __tablename__ = 'account'
+        __lazy_options__ = lazy_options
 
-    def create_models(self, **options):
-        class Account(self.Model):
-            __tablename__ = 'user'
-            __lazy_options__ = options
+        id = Column(sa.Integer, primary_key=True)
+        balance = Column(
+            sa.Float,
+            min=0,
+            max=120000,
+            default=0
+        )
+    return Account
 
-            id = Column(sa.Integer, primary_key=True)
-            balance = Column(
-                sa.Float,
-                min=0,
-                max=120000,
-                default=0
-            )
 
-        self.Account = Account
-        self.columns = Account.__table__.c
+@pytest.fixture
+def models(Account):
+    return [Account]
 
-    def test_assigns_real_server_defaults(self):
-        assert self.columns.balance.server_default.arg == '0'
+
+@pytest.mark.usefixtures('lazy_configured')
+class TestFloatDefaults(object):
+
+    def test_assigns_real_server_defaults(self, Account):
+        assert Account.__table__.c.balance.server_default.arg == '0'

--- a/tests/test_integer_defaults.py
+++ b/tests/test_integer_defaults.py
@@ -1,39 +1,49 @@
 # -*- coding: utf-8 -*-
+import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_defaults import Column
-from tests import TestCase
 
 
-class TestIntegerDefaults(TestCase):
-    column_options = {}
+@pytest.mark.usefixtures('lazy_configured')
+class TestIntegerDefaults(object):
 
-    def create_models(self, **options):
-        class User(self.Model):
+    @pytest.fixture
+    def User(self, Base, lazy_options):
+        class User(Base):
             __tablename__ = 'user'
-            __lazy_options__ = options
+            __lazy_options__ = lazy_options
 
             id = Column(sa.Integer, primary_key=True)
             name = Column(sa.Unicode(255))
             age = Column(sa.Integer, info={'min': 13, 'max': 120}, default=16)
 
-        self.User = User
+        return User
 
-    def test_assigns_int_server_defaults(self):
-        assert self.columns.age.server_default.arg == '16'
+    @pytest.fixture
+    def models(self, User):
+        return [User]
+
+    def test_assigns_int_server_defaults(self, User):
+        assert User.__table__.c.age.server_default.arg == '16'
 
 
-class TestIntegerWithSequence(TestCase):
-    column_options = {}
+@pytest.mark.usefixtures('lazy_configured')
+class TestIntegerWithSequence(object):
 
-    def create_models(self, **options):
-        class User(self.Model):
+    @pytest.fixture
+    def User(self, Base, lazy_options):
+        class User(Base):
             __tablename__ = 'user'
-            __lazy_options__ = options
+            __lazy_options__ = lazy_options
 
             id = Column(sa.Integer, sa.Sequence('id_seq'), primary_key=True)
 
-        self.User = User
+        return User
 
-    def test_assigns_int_server_defaults(self):
-        assert isinstance(self.columns.id.default, sa.Sequence)
+    @pytest.fixture
+    def models(self, User):
+        return [User]
+
+    def test_assigns_int_server_defaults(self, User):
+        assert isinstance(User.__table__.c.id.default, sa.Sequence)

--- a/tests/test_lazy_configurable.py
+++ b/tests/test_lazy_configurable.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
+import pytest
 import six
 import sqlalchemy as sa
 
 from sqlalchemy_defaults import Column
-from tests import TestCase
 
 
-class TestLazyConfigurableDefaults(TestCase):
-    column_options = {}
+@pytest.mark.usefixtures('lazy_configured')
+class TestLazyConfigurableDefaults(object):
 
-    def create_models(self, **options):
-        class User(self.Model):
+    @pytest.fixture
+    def User(self, Base, lazy_options):
+
+        class User(Base):
             __tablename__ = 'user'
-            __lazy_options__ = options
+            __lazy_options__ = lazy_options
 
             id = Column(sa.Integer, primary_key=True)
             name = Column(sa.Unicode(255))
@@ -29,50 +31,62 @@ class TestLazyConfigurableDefaults(TestCase):
             favorite_buddy = Column(sa.Unicode(255), default=u'Örrimörri')
             description = Column(sa.UnicodeText)
 
-        class Article(self.Model):
+        return User
+
+    @pytest.fixture
+    def Article(self, Base, User, lazy_options):
+
+        class Article(Base):
             __tablename__ = 'article'
-            __lazy_options__ = options
+            __lazy_options__ = lazy_options
             id = Column(sa.Integer, primary_key=True)
             name = Column(sa.Unicode(255))
             author_id = Column(sa.Integer, sa.ForeignKey(User.id))
 
-        self.User = User
-        self.Article = Article
+        return Article
 
-    def test_creates_min_and_max_check_constraints(self):
+    @pytest.fixture
+    def models(self, User, Article):
+        return [User, Article]
+
+    def test_creates_min_and_max_check_constraints(self, User, engine):
         from sqlalchemy.schema import CreateTable
 
         sql = six.text_type(
-            CreateTable(self.User.__table__).compile(self.engine)
+            CreateTable(User.__table__).compile(engine)
         )
         assert 'CHECK (age >= 13)' in sql
         assert 'CHECK (age <= 120)' in sql
 
-    def test_assigns_int_server_defaults(self):
-        assert self.columns.age.server_default.arg == '16'
+    def test_assigns_int_server_defaults(self, User):
+        assert User.__table__.c.age.server_default.arg == '16'
 
-    def test_assigns_indexes_for_foreign_keys(self):
-        assert self.Article.__table__.c.author_id.index is True
+    def test_assigns_indexes_for_foreign_keys(self, Article):
+        assert Article.__table__.c.author_id.index is True
 
-    def test_insert(self):
-        user = self.User(name=u'Someone', description=u'Some description')
-        self.session.add(user)
-        self.session.commit()
+    def test_insert(self, User, session):
+        user = User(name=u'Someone', description=u'Some description')
+        session.add(user)
+        session.commit()
 
 
-class TestLazyConfigurableOptionOverriding(TestCase):
-    column_options = {
-        'min_max_check_constraints': False,
-        'string_defaults': False,
-        'numeric_defaults': False,
-        'boolean_defaults': False,
-        'auto_now': False
-    }
+@pytest.mark.usefixtures('lazy_configured')
+class TestLazyConfigurableOptionOverriding(object):
+    @pytest.fixture
+    def lazy_options(self):
+        return {
+            'min_max_check_constraints': False,
+            'string_defaults': False,
+            'numeric_defaults': False,
+            'boolean_defaults': False,
+            'auto_now': False
+        }
 
-    def create_models(self, **options):
-        class User(self.Model):
+    @pytest.fixture
+    def User(self, Base, lazy_options):
+        class User(Base):
             __tablename__ = 'user'
-            __lazy_options__ = options
+            __lazy_options__ = lazy_options
 
             id = Column(sa.Integer, primary_key=True)
             name = Column(sa.Unicode(255))
@@ -89,40 +103,45 @@ class TestLazyConfigurableOptionOverriding(TestCase):
             favorite_buddy = Column(sa.Unicode(255), default=u'Örrimörri')
             created_at = Column(sa.DateTime, info={'auto_now': True})
             description = Column(sa.UnicodeText)
+        return User
 
-        class Article(self.Model):
+    @pytest.fixture
+    def Article(self, Base, User, lazy_options):
+        class Article(Base):
             __tablename__ = 'article'
-            __lazy_options__ = options
+            __lazy_options__ = lazy_options
             id = Column(sa.Integer, primary_key=True)
             name = Column(sa.Unicode(255))
             author_id = Column(sa.Integer, sa.ForeignKey(User.id))
+        return Article
 
-        self.User = User
-        self.Article = Article
+    @pytest.fixture
+    def models(self, User, Article):
+        return [User, Article]
 
-    def test_check_constraints(self):
+    def test_check_constraints(self, User, engine):
         from sqlalchemy.schema import CreateTable
 
-        sql = str(CreateTable(self.User.__table__).compile(self.engine))
+        sql = str(CreateTable(User.__table__).compile(engine))
         assert 'CHECK (age >= 13)' not in sql
         assert 'CHECK (age <= 120)' not in sql
 
-    def test_booleans_defaults(self):
-        assert self.columns.is_active.nullable is False
-        assert self.columns.is_active.default is None
+    def test_booleans_defaults(self, User):
+        assert User.__table__.c.is_active.nullable is False
+        assert User.__table__.c.is_active.default is None
 
-        is_admin = self.columns.is_admin
-        is_active = self.columns.is_active
+        is_admin = User.__table__.c.is_admin
+        is_active = User.__table__.c.is_active
         assert is_admin.server_default is None
         assert is_active.server_default is None
 
-    def test_string_defaults(self):
-        assert self.columns.hobbies.server_default is None
+    def test_string_defaults(self, User):
+        assert User.__table__.c.hobbies.server_default is None
 
-    def test_integer_defaults(self):
-        assert self.columns.age.server_default is None
+    def test_integer_defaults(self, User):
+        assert User.__table__.c.age.server_default is None
 
-    def test_auto_now(self):
-        created_at = self.columns.created_at
+    def test_auto_now(self, User):
+        created_at = User.__table__.c.created_at
         assert not created_at.default
         assert not created_at.server_default

--- a/tests/test_numeric_defaults.py
+++ b/tests/test_numeric_defaults.py
@@ -1,28 +1,34 @@
 # -*- coding: utf-8 -*-
+import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_defaults import Column
-from tests import TestCase
 
 
-class TestNumericDefaults(TestCase):
-    column_options = {}
+@pytest.fixture
+def Account(Base, lazy_options):
+    class Account(Base):
+        __tablename__ = 'user'
+        __lazy_options__ = lazy_options
 
-    def create_models(self, **options):
-        class Account(self.Model):
-            __tablename__ = 'user'
-            __lazy_options__ = options
+        id = Column(sa.Integer, primary_key=True)
+        balance = Column(
+            sa.Numeric,
+            min=0,
+            max=2000,
+            default=100
+        )
+    return Account
 
-            id = Column(sa.Integer, primary_key=True)
-            balance = Column(
-                sa.Numeric,
-                min=0,
-                max=2000,
-                default=100
-            )
 
-        self.Account = Account
-        self.columns = Account.__table__.c
+@pytest.fixture
+def models(Account):
+    return [Account]
 
-    def test_assigns_real_server_defaults(self):
-        assert self.columns.balance.server_default.arg == '100'
+
+@pytest.mark.usefixtures('lazy_configured')
+class TestNumericDefaults(object):
+
+    @pytest.fixture
+    def test_assigns_real_server_defaults(self, Account):
+        assert Account.__table__.c.balance.server_default.arg == '100'

--- a/tests/test_string_defaults.py
+++ b/tests/test_string_defaults.py
@@ -37,6 +37,10 @@ class TestStringDefaults(TestCase):
     def test_assigns_string_server_defaults(self):
         assert self.columns.hobbies.server_default.arg == u'football'
 
+    def test_empty_default_and_server_default(self):
+        assert self.columns.name.default.arg == u''
+        assert self.columns.name.server_default.arg == u''
+
     def test_override_server_default(self):
         assert self.columns.hobbies2.server_default.arg == u''
 

--- a/tests/test_string_defaults.py
+++ b/tests/test_string_defaults.py
@@ -1,48 +1,54 @@
 # -*- coding: utf-8 -*-
+import pytest
 import sqlalchemy as sa
 
 from sqlalchemy_defaults import Column
-from tests import TestCase
 
 
-class TestStringDefaults(TestCase):
-    column_options = {}
+@pytest.fixture
+def User(Base, lazy_options):
+    class User(Base):
+        __tablename__ = 'user'
+        __lazy_options__ = lazy_options
 
-    def create_models(self, **options):
-        class User(self.Model):
-            __tablename__ = 'user'
-            __lazy_options__ = options
+        id = Column(sa.Integer, primary_key=True)
+        name = Column(sa.Unicode(255))
+        hobbies = Column(sa.Unicode(255), default=u'football')
+        hobbies2 = Column(
+            sa.Unicode(255), default=u'ice-hockey', server_default=u''
+        )
 
-            id = Column(sa.Integer, primary_key=True)
-            name = Column(sa.Unicode(255))
-            hobbies = Column(sa.Unicode(255), default=u'football')
-            hobbies2 = Column(
-                sa.Unicode(255), default=u'ice-hockey', server_default=u''
-            )
+        favorite_hobbies = Column(sa.Unicode(255), default=lambda ctx: (
+            ctx.current_parameters['hobbies']
+            if ctx.current_parameters['hobbies'] is not None
+            else u'football'
+        ))
+        favorite_buddy = Column(sa.Unicode(255), default=u'Örrimörri')
+        description = Column(sa.UnicodeText)
+    return User
 
-            favorite_hobbies = Column(sa.Unicode(255), default=lambda ctx: (
-                ctx.current_parameters['hobbies']
-                if ctx.current_parameters['hobbies'] is not None
-                else u'football'
-            ))
-            favorite_buddy = Column(sa.Unicode(255), default=u'Örrimörri')
-            description = Column(sa.UnicodeText)
 
-        self.User = User
+@pytest.fixture
+def models(User):
+    return [User]
 
-    def test_strings_not_nullable(self):
-        assert self.columns.name.nullable is False
-        assert self.columns.description.nullable is False
 
-    def test_assigns_string_server_defaults(self):
-        assert self.columns.hobbies.server_default.arg == u'football'
+@pytest.mark.usefixtures('lazy_configured')
+class TestStringDefaults(object):
 
-    def test_empty_default_and_server_default(self):
-        assert self.columns.name.default.arg == u''
-        assert self.columns.name.server_default.arg == u''
+    def test_strings_not_nullable(self, User):
+        assert User.__table__.c.name.nullable is False
+        assert User.__table__.c.description.nullable is False
 
-    def test_override_server_default(self):
-        assert self.columns.hobbies2.server_default.arg == u''
+    def test_assigns_string_server_defaults(self, User):
+        assert User.__table__.c.hobbies.server_default.arg == u'football'
 
-    def test_doesnt_assign_string_server_defaults_for_callables(self):
-        assert self.columns.favorite_hobbies.server_default is None
+    def test_empty_default_and_server_default(self, User):
+        assert User.__table__.c.name.default.arg == u''
+        assert User.__table__.c.name.server_default.arg == u''
+
+    def test_override_server_default(self, User):
+        assert User.__table__.c.hobbies2.server_default.arg == u''
+
+    def test_doesnt_assign_string_server_defaults_for_callables(self, User):
+        assert User.__table__.c.favorite_hobbies.server_default is None

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,19 @@
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py{26,27,33,34,35}-{sqlite,postgresql,mysql},lint
 
 [testenv]
-commands = pip install -e ".[test]"
-           py.test
-install_command = pip install {packages}
-passenv = DB DSN
+setenv =
+    py{26,27,33,34,35}-sqlite: DSN={env:SQLITE_DSN:}
+    py{26,27,33,34,35}-postgresql: DSN={env:POSTGRESQL_DSN}
+    py{26,27,33,34,35}-mysql: DSN={env:MYSQL_DSN}
+commands = py.test -s
+install_command = pip install {packages} -e ".[test]"
+passenv = DSN
+
+[testenv:lint]
+commands =
+    flake8 sqlalchemy_defaults tests
+    isort --recursive --diff sqlalchemy_defaults tests
+    isort --recursive --check-only sqlalchemy_defaults tests
+install_command =
+    pip install {packages} -e ".[test]" flake8>=2.5.0 isort>=4.2.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
-envlist = py26, py27, py33, py34
+envlist = py26, py27, py33, py34, py35
 
 [testenv]
 commands = pip install -e ".[test]"
            py.test
 install_command = pip install {packages}
+passenv = DB DSN


### PR DESCRIPTION
If both default and server_default are None then set them to empty strings as default. As we’re already forcing `nullable=False` on the field this feels pretty sensible.

This commit is backwards incompatible for MySQL users as they now need to set the option `text_server_defaults=False` if they use Text columns in their models. Added the ability to pass in options directly to `make_lazy_configured` to ease the pain somewhat. I've added some documentation on this. While I was at it I also added documentation about `auto_now=True` not working below MySQL 5.6.5.
