### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,6 @@ To type a bit less to run the tests you can save the command in a script:
 Resources
 ---------
 
-- `Documentation <http://sqlalchemy-defaults.readthedocs.org/>`_
+- `Documentation <https://sqlalchemy-defaults.readthedocs.io/>`_
 - `Issue Tracker <http://github.com/kvesteri/sqlalchemy-defaults/issues>`_
 - `Code <http://github.com/kvesteri/sqlalchemy-defaults/>`_


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
